### PR TITLE
Add a method to set generic AVOptions

### DIFF
--- a/source/ffmpeg-cpp/encode_video/encode_video.cpp
+++ b/source/ffmpeg-cpp/encode_video/encode_video.cpp
@@ -22,7 +22,7 @@ int main()
 		codec->SetQualityScale(0);
 
 		// Set the bit rate option -b:v 2M
-		codec->SetGlobalOption("b", "2M");
+		codec->SetGenericOption("b", "2M");
 
 		// Create an encoder that will encode the raw audio data as MP3.
 		// Tie it to the muxer so it will be written to the file.

--- a/source/ffmpeg-cpp/encode_video/encode_video.cpp
+++ b/source/ffmpeg-cpp/encode_video/encode_video.cpp
@@ -21,6 +21,9 @@ int main()
 		// parameter -qscale and must be within range [0,31].
 		codec->SetQualityScale(0);
 
+		// Set the bit rate option -b:v 2M
+		codec->SetGlobalOption("b", "2M");
+
 		// Create an encoder that will encode the raw audio data as MP3.
 		// Tie it to the muxer so it will be written to the file.
 		VideoEncoder* encoder = new VideoEncoder(codec, muxer);

--- a/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.cpp
+++ b/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.cpp
@@ -35,6 +35,11 @@ namespace ffmpegcpp
 		av_opt_set_double(codecContext->priv_data, name, value, 0);
 	}
 
+	void Codec::SetGlobalOption(const char* name, const char* value)
+	{
+		av_opt_set(codecContext, name, value);
+	}
+
 	AVCodecContext* Codec::LoadContext(AVCodec* codec)
 	{
 		AVCodecContext* codecContext = avcodec_alloc_context3(codec);

--- a/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.cpp
+++ b/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.cpp
@@ -35,7 +35,7 @@ namespace ffmpegcpp
 		av_opt_set_double(codecContext->priv_data, name, value, 0);
 	}
 
-	void Codec::SetGlobalOption(const char* name, const char* value)
+	void Codec::SetGenericOption(const char* name, const char* value)
 	{
 		av_opt_set(codecContext, name, value);
 	}

--- a/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.cpp
+++ b/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.cpp
@@ -37,7 +37,7 @@ namespace ffmpegcpp
 
 	void Codec::SetGenericOption(const char* name, const char* value)
 	{
-		av_opt_set(codecContext, name, value);
+		av_opt_set(codecContext, name, value, 0);
 	}
 
 	AVCodecContext* Codec::LoadContext(AVCodec* codec)

--- a/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.h
+++ b/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.h
@@ -20,7 +20,7 @@ namespace ffmpegcpp
 		void SetOption(const char* name, int value);
 		void SetOption(const char* name, double value);
 
-		void SetGlobalOption(const char* name, const char* value);
+		void SetGenericOption(const char* name, const char* value);
 
 		void SetGlobalContainerHeader(); // used by the Muxer for configuration purposes
 

--- a/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.h
+++ b/source/ffmpeg-cpp/ffmpeg-cpp/Codecs/Codec.h
@@ -20,6 +20,8 @@ namespace ffmpegcpp
 		void SetOption(const char* name, int value);
 		void SetOption(const char* name, double value);
 
+		void SetGlobalOption(const char* name, const char* value);
+
 		void SetGlobalContainerHeader(); // used by the Muxer for configuration purposes
 
 	protected:


### PR DESCRIPTION
I find that the existing Codec::SetOption method cannot be used to set bit rate parameter.  Therefore I add a new helper method to set generic AvOptions, e.g. it allows the user to specify the bit rate  parameter, as demonstrated in the  encode_video example. 